### PR TITLE
Adding in extra detail as per the teamcity spec for suites

### DIFF
--- a/lib/teamcity.js
+++ b/lib/teamcity.js
@@ -26,11 +26,11 @@ function Teamcity(runner) {
   });
 
   runner.on('test', function(test) {
-    console.log("##teamcity[testStarted name='" + escape(test.fullTitle()) + "']");
+    console.log("##teamcity[testStarted name='" + escape(test.fullTitle()) + "' captureStandardOutput='true']");
   });
 
   runner.on('fail', function(test, err) {
-    console.log("##teamcity[testFailed name='" + escape(test.fullTitle()) + "' message='" + escape(err.message) + "']");
+    console.log("##teamcity[testFailed name='" + escape(test.fullTitle()) + "'" + (err.message ? (" message='" + escape(err.message) + "'" ) : "" ) + " details='message and stack trace' expected='" + escape(err.expected) + "' actual='" + escape(err.actual) + "']");
   });
 
   runner.on('pending', function(test) {
@@ -41,9 +41,23 @@ function Teamcity(runner) {
     console.log("##teamcity[testFinished name='" + escape(test.fullTitle()) + "' duration='" + test.duration + "']");
   });
 
+  runner.on('suite', function(suite){
+    suite.startDate = new Date();
+    if(suite.fullTitle() != ""){
+      console.log("##teamcity[testSuiteStarted name='" + escape(suite.fullTitle()) + "']");
+    }
+  });
+
+  runner.on('suite end', function(suite){
+    if(suite.fullTitle() != ""){
+      console.log("##teamcity[testSuiteFinished name='" + escape(suite.fullTitle()) + "' duration='" + (new Date() - suite.startDate) + "']");
+    }
+  });
+
   runner.on('end', function() {
     console.log("##teamcity[testSuiteFinished name='mocha.suite' duration='" + stats.duration + "']");
   });
+
 }
 
 /**


### PR DESCRIPTION
Also include the expected / actual results

And reference http://confluence.jetbrains.com/display/TCD7/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-ReportingTests for standards

Meant to get round to removing teamcity reporter from mocha but didnt get round to it and see you have, thanks! Here's the improvements added to the mocha one - tested with an install of teamcity and all seems to work

Will leave it up to you to change package.json and README.md if you want to include this
