### PR TITLE
Up version of mocha required in the package.json file to avoid warnings ...

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "jetbrains"
   ],
   "dependencies": {
-    "mocha": "1.13.0"
+    "mocha": ">=1.13.0"
   },
   "author": "travis jeffery",
   "license": "MIT",


### PR DESCRIPTION
...when running npm install using a higher version of mocha.
