### PR TITLE
Remove unopened testSuiteFinished

### DIFF
--- a/lib/teamcity.js
+++ b/lib/teamcity.js
@@ -46,10 +46,6 @@ function Teamcity(runner) {
     if (suite.root) return;
     console.log("##teamcity[testSuiteFinished name='" + escape(suite.title) + "' duration='" + (new Date() - suite.startDate) + "']");
   });
-
-  runner.on('end', function() {
-    console.log("##teamcity[testSuiteFinished name='mocha.suite' duration='" + stats.duration + "']");
-  });
 }
 
 /**


### PR DESCRIPTION
This was removed in e6adedc0c421f05624e5b36ec5c8985687a6a50b but was added again in bbbba3136bc9185bfb246a9b5d553a1e4f83b7ae (whether on purpose or not...).

I don't know if finishing a testSuite without starting one is acceptable or not, but there is no point closing something that was never openeded.
