### PR TITLE
Support mocha-phantomjs test environments.

### DIFF
--- a/lib/teamcity.js
+++ b/lib/teamcity.js
@@ -4,14 +4,14 @@
 
 var Base, log;
 
-try {
-  // running in mocha-phantomjs?
-  Base = require('./base');
-  log = function(msg) { process.stdout.write(msg + "\n"); };
-} catch (ignored) {
+if (typeof window === 'undefined') {
   // running in Node
   Base = require('mocha').reporters.Base;
   log = console.log;
+} else {
+  // running in mocha-phantomjs
+  Base = require('./base');
+  log = function(msg) { process.stdout.write(msg + "\n"); };
 }
 
 /**


### PR DESCRIPTION
This modifies the teamcity reporter to check whether a phantomjs environment is present and, if so, behave in a way that's compatible with `mocha-phantomjs`. This means reporters [can only require other reporters and should use process.stdout.write to report progress](https://github.com/metaskills/mocha-phantomjs#third-party-reporters).

If execution is in a Node environment, the previous behaviour is unchanged.
