### PR TITLE
pending tests crash mocha

### DIFF
--- a/lib/teamcity.js
+++ b/lib/teamcity.js
@@ -69,6 +69,7 @@ function Teamcity(runner) {
 function escape(str) {
   if (!str) return '';
   return str
+    .toString()
     .replace(/\|/g, "||")
     .replace(/\n/g, "|n")
     .replace(/\r/g, "|r")


### PR DESCRIPTION
it seems test.title is sometimes an object, which is not a string and fails since there's no replace method on an object. toString() fixes the issue.
