### PR TITLE
mocha-teamcity-reporter may fail to initialize if 'window' is present

### DIFF
--- a/lib/teamcity.js
+++ b/lib/teamcity.js
@@ -4,14 +4,19 @@
 
 var Base, log;
 
-if (typeof window === 'undefined') {
+if (typeof window !== 'undefined') {
+  // possibly running in mocha-phantomjs
+  try {
+    Base = require('./base');
+    log = function(msg) { process.stdout.write(msg + "\n"); };
+  } catch (ignored) {
+  }
+}
+
+if (typeof Base === 'undefined') {
   // running in Node
   Base = require('mocha').reporters.Base;
   log = console.log;
-} else {
-  // running in mocha-phantomjs
-  Base = require('./base');
-  log = function(msg) { process.stdout.write(msg + "\n"); };
 }
 
 /**


### PR DESCRIPTION
Commit 7071661d checks if 'window' is defined. I do have 'window' available in global scope but I'm not running in mocha-phantomjs. In that case `require('./base')` fails and the reporter does not initialize.

This commit avoids making `require('./base')` mandatory in case 'window' is present.
