### PR TITLE
Remove escape sequences from reporting

### DIFF
--- a/lib/teamcity.js
+++ b/lib/teamcity.js
@@ -71,6 +71,7 @@ function escape(str) {
   if (!str) return '';
   return str
     .toString()
+    .replace(/\x1B.*?m/g, "")
     .replace(/\|/g, "||")
     .replace(/\n/g, "|n")
     .replace(/\r/g, "|r")


### PR DESCRIPTION
Removing escaping sequences, since the TeamCity reporter cannot use them to show correctly the colors passed.