### PR TITLE
Wrap report in blockOpened/blockClosed

### DIFF
--- a/lib/teamcity.js
+++ b/lib/teamcity.js
@@ -31,6 +31,10 @@ function Teamcity(runner) {
   Base.call(this, runner);
   var stats = this.stats;
 
+  runner.on('start', function(){
+    log("##teamcity[blockOpened name='Mocha tests report']");
+  });
+  
   runner.on('suite', function(suite) {
     if (suite.root) return;
     suite.startDate = new Date();
@@ -59,7 +63,7 @@ function Teamcity(runner) {
   });
 
   runner.on('end', function() {
-    log("##teamcity[testSuiteFinished name='mocha.suite' duration='" + stats.duration + "']");
+    log("##teamcity[blockClosed name='Mocha tests report']");
   });
 }
 

--- a/lib/teamcity.js
+++ b/lib/teamcity.js
@@ -31,12 +31,13 @@ function Teamcity(runner) {
   Base.call(this, runner);
   var stats = this.stats;
 
-  runner.on('start', function(){
-    log("##teamcity[blockOpened name='Mocha tests report']");
-  });
+  runner.on('start', function(suite) {
+    log("##teamcity[testSuiteStarted name='mocha.suite']")
+  })
   
   runner.on('suite', function(suite) {
     if (suite.root) return;
+    
     suite.startDate = new Date();
     log("##teamcity[testSuiteStarted name='" + escape(suite.title) + "']");
   });
@@ -60,11 +61,13 @@ function Teamcity(runner) {
   runner.on('suite end', function(suite) {
     if (suite.root) return;
     log("##teamcity[testSuiteFinished name='" + escape(suite.title) + "' duration='" + (new Date() - suite.startDate) + "']");
+    log();
   });
 
   runner.on('end', function() {
-    log("##teamcity[blockClosed name='Mocha tests report']");
-  });
+    log("##teamcity[testSuiteFinished name='mocha.suite' duration='" + this.stats.duration + "']");
+    log();
+  }.bind(this));
 }
 
 /**


### PR DESCRIPTION
There was no opening message for runner 'start' event.
