### PR TITLE
don't make commonjs export and hoisting to window mutually exclusive

### DIFF
--- a/lib/teamcity.js
+++ b/lib/teamcity.js
@@ -24,7 +24,9 @@ if (typeof window === 'undefined') {
 
 if (typeof window !== 'undefined' && window.Mocha && window.Mocha.reporters) {
   window.Mocha.reporters.teamcity = Teamcity
-}else{
+}
+
+if (typeof module !== 'undefined' && module.exports) {
   exports = module.exports = Teamcity
 }
 


### PR DESCRIPTION
In mocha-casperjs for example, window will be defined at runtime, but
reporters are still loaded via a commonjs require call
