### PR TITLE
Support tests running in node with jsDom

### DIFF
--- a/lib/teamcity.js
+++ b/lib/teamcity.js
@@ -4,7 +4,7 @@
 
 var Base, log
 
-if (typeof window === 'undefined') {
+if (typeof window === 'undefined' || window.name === 'nodejs') {
   // running in Node
   Base = require('mocha').reporters.Base
   log = console.log


### PR DESCRIPTION
When running tests in node with jsDom the result is that the reporter thinks that we are running the tests in mocha-phantomjs due to the only check for node is if window is undefined. JsDom sets window but the tests are still being run in node.
 