### PR TITLE
Reporter fails to report the error to TeamCity properly. If the error happens inside before or after block.

### DIFF
--- a/lib/teamcity.js
+++ b/lib/teamcity.js
@@ -46,10 +46,14 @@ function Teamcity(runner) {
   })
 
   runner.on('test', function(test) {
+    test.startPrinted = true;
     log('##teamcity[testStarted name=\'' + escape(test.title) + '\' captureStandardOutput=\'true\']')
   })
 
   runner.on('fail', function(test, err) {
+    if (test.startPrinted !== true) {
+      log('##teamcity[testStarted name=\'' + escape(test.title) + '\' captureStandardOutput=\'true\']')
+    }
     log('##teamcity[testFailed name=\'' + escape(test.title) + '\' message=\'' + escape(err.message) + '\' captureStandardOutput=\'true\' details=\'' + escape(err.stack) + '\']')
   })
 


### PR DESCRIPTION
This pull request will make sure it will always print out start/end pair or start/fail pair.
It makes TeamCity able to detect the test.

Tested on TeamCity Enterprise 2017.1 (build 46533)