### PR TITLE
reporterOptions are optional

### DIFF
--- a/lib/teamcity.js
+++ b/lib/teamcity.js
@@ -74,7 +74,7 @@ function formatString() {
  */
 
 function Teamcity(runner, options) {
-	const reporterOptions = options.reporterOptions;
+	const reporterOptions = options.reporterOptions || {};
 	let flowId;
 	(reporterOptions.flowId) ? flowId = reporterOptions.flowId : flowId =  process.env['MOCHA_TEAMCITY_FLOWID'] || processPID;
 	Base.call(this, runner);


### PR DESCRIPTION
If Mocha started from command line, it [defines](https://github.com/mochajs/mocha/blob/575d83d76b97dfa426ee9f1aa436e27f9e96b283/bin/_mocha#L205) `reporterOptions` automatically.

When using Mocha programmatically, the `reporterOptions` object isn't defined.

Built-in reporters [treat](https://github.com/mochajs/mocha/blob/5be22b23480f27679fbc0d6dd21ce6e4085029c4/lib/reporters/progress.js#L42) this property as optional.