### PR TITLE
Bugfix/54 - Implement 'hook end' event

### DIFF
--- a/lib/teamcity.js
+++ b/lib/teamcity.js
@@ -82,6 +82,7 @@ function Teamcity(runner, options) {
 	(reporterOptions.ignoreHookWithName) ? ignoreHookWithName = reporterOptions.ignoreHookWithName : ignoreHookWithName = process.env['IGNORE_HOOK_WITH_NAME'];
 	(useStdError) ? useStdError = (useStdError.toLowerCase() === 'true') : useStdError = false;
 	(recordHookFailures) ? recordHookFailures = (recordHookFailures.toLowerCase() === 'true') : recordHookFailures = false;
+	(ignoreHookWithName) ? ignoreHookWithName : null;
 	actualVsExpected ? actualVsExpected = (actualVsExpected.toLowerCase() === 'true') : actualVsExpected = false;
 	Base.call(this, runner);
 	let stats = this.stats;
@@ -117,7 +118,7 @@ function Teamcity(runner, options) {
 			}
 		}
 		// Log testFinished for failed hook (hook end event is not fired for failed hook)
-		if (recordHookFailures && !test.title.includes(ignoreHookWithName)) {
+		if (recordHookFailures && !ignoreHookWithName || recordHookFailures && ignoreHookWithName && !test.title.includes(ignoreHookWithName)) {
 			if (test.title.includes(`"before all" hook`)
 					|| test.title.includes(`"before each" hook`) 
 					|| test.title.includes(`"after all" hook`)
@@ -145,13 +146,13 @@ function Teamcity(runner, options) {
 	});
 
 	runner.on('hook', function (test) {
-		if (recordHookFailures && !test.title.includes(ignoreHookWithName)) {
+		if (recordHookFailures && !ignoreHookWithName || recordHookFailures && ignoreHookWithName && !test.title.includes(ignoreHookWithName)) {
 			log(formatString(TEST_START, test.title, flowId));
 		}
 	});
 
 	runner.on('hook end', function (test) {
-		if (recordHookFailures && !test.title.includes(ignoreHookWithName)) {
+		if (recordHookFailures && !ignoreHookWithName || recordHookFailures && ignoreHookWithName && !test.title.includes(ignoreHookWithName)) {
 			if(isNil(test.duration)){
 				log(formatString(TEST_END_NO_DURATION, test.title, flowId));
 			} else {

--- a/lib/teamcity.js
+++ b/lib/teamcity.js
@@ -116,6 +116,20 @@ function Teamcity(runner, options) {
 				log(formatString(TEST_FAILED, test.title, err.message, err.stack, flowId));
 			}
 		}
+		// Log testFinished for failed hook (hook end event is not fired for failed hook)
+		if (recordHookFailures && !test.title.includes(ignoreHookWithName)) {
+			if (test.title.includes(`"before all" hook`)
+					|| test.title.includes(`"before each" hook`) 
+					|| test.title.includes(`"after all" hook`)
+					|| test.title.includes(`"after each" hook`)
+				) {
+				if(isNil(test.duration)){
+					log(formatString(TEST_END_NO_DURATION, test.title, flowId));
+				} else {
+					log(formatString(TEST_END, test.title, test.duration.toString(), flowId));
+				}
+			}
+		}
 	});
 
 	runner.on('pending', function (test) {
@@ -133,6 +147,16 @@ function Teamcity(runner, options) {
 	runner.on('hook', function (test) {
 		if (recordHookFailures && !test.title.includes(ignoreHookWithName)) {
 			log(formatString(TEST_START, test.title, flowId));
+		}
+	});
+
+	runner.on('hook end', function (test) {
+		if (recordHookFailures && !test.title.includes(ignoreHookWithName)) {
+			if(isNil(test.duration)){
+				log(formatString(TEST_END_NO_DURATION, test.title, flowId));
+			} else {
+				log(formatString(TEST_END, test.title, test.duration.toString(), flowId));
+			}
 		}
 	});
 

--- a/test/example/failingIgnoreHookNoRoot.js
+++ b/test/example/failingIgnoreHookNoRoot.js
@@ -9,7 +9,8 @@ describe('Hook Test Top Describe Fail', function () {
 		assert.strictEqual(1, 1);
 	});
 
-	beforeEach(function beforeEachHookNoReporting() {
+	// Name of the function is an additional check for case when ignoreHookWithName is undefined
+	beforeEach(function undefinedbeforeEachHookNoReporting() {
 		throw new Error('Before each hook error fail');
 	});
 
@@ -17,7 +18,8 @@ describe('Hook Test Top Describe Fail', function () {
 		assert.strictEqual(1, 1);
 	});
 
-	afterEach(function afterEachHook() {
+	// Name of the function is an additional check for case when ignoreHookWithName is undefined
+	afterEach(function undefinedafterEachHook() {
 		throw new Error('After each hook error fail');
 	});
 

--- a/test/functional/ignoreHookWithNameDisabled.js
+++ b/test/functional/ignoreHookWithNameDisabled.js
@@ -11,8 +11,8 @@ describe('Check TeamCity Output is correct with recordHookFailures but with no i
 		it('1 stdout output should exist', function () {
 			assert.isOk(teamCityStdout, 'has output');
 			assert.isOk(teamCityOutputArray, 'array of output is populated');
-			assert.lengthOf(teamCityOutputArray, 24);
-			assert.isEmpty(teamCityOutputArray[23]);
+			assert.lengthOf(teamCityOutputArray, 34);
+			assert.isEmpty(teamCityOutputArray[33]);
 		});
 
 		it('2 stderr output should not exist', function () {
@@ -35,24 +35,33 @@ describe('Check TeamCity Output is correct with recordHookFailures but with no i
 			assert.match(rowToCheck, /]/);
 		});
 
-		it('5 Passing test testStarted', function () {
+		it('5 Before all testFinished', function () {
 			const rowToCheck = teamCityOutputArray[2];
+			assert.match(rowToCheck, /##teamcity\[testFinished/);
+			assert.match(rowToCheck, /name='"before all" hook/);
+			assert.match(rowToCheck, /flowId=/);
+			assert.match(rowToCheck, /duration=/);
+			assert.match(rowToCheck, /]/);
+		});
+
+		it('6 Passing test testStarted', function () {
+			const rowToCheck = teamCityOutputArray[3];
 			assert.isOk(/##teamcity\[testStarted/.test(rowToCheck));
 			assert.isOk(/name='Test Passing Test @pass'/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
-		it('6 Before each hook testStarted', function () {
-			const rowToCheck = teamCityOutputArray[3];
+		it('7 Before each hook testStarted', function () {
+			const rowToCheck = teamCityOutputArray[4];
 			assert.isOk(/##teamcity\[testStarted/.test(rowToCheck));
 			assert.isOk(/name='"before each" hook: beforeEachHookNoReporting/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
-		it('7 Before each hook testFailed', function () {
-			const rowToCheck = teamCityOutputArray[4];
+		it('8 Before each hook testFailed', function () {
+			const rowToCheck = teamCityOutputArray[5];
 			assert.isOk(/##teamcity\[testFailed/.test(rowToCheck));
 			assert.isOk(/"before each" hook: beforeEachHookNoReporting/.test(rowToCheck));
 			assert.isOk(/message='Before each hook error fail'/.test(rowToCheck));
@@ -60,8 +69,17 @@ describe('Check TeamCity Output is correct with recordHookFailures but with no i
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
+		it('9 Before all testFinished', function () {
+			const rowToCheck = teamCityOutputArray[6];
+			assert.match(rowToCheck, /##teamcity\[testFinished/);
+			assert.match(rowToCheck, /"before each" hook: beforeEachHookNoReporting/);
+			assert.match(rowToCheck, /flowId=/);
+			assert.match(rowToCheck, /duration=/);
+			assert.match(rowToCheck, /]/);
+		});
+
 		it('8 After each hook testStarted', function () {
-			const rowToCheck = teamCityOutputArray[5];
+			const rowToCheck = teamCityOutputArray[7];
 			assert.isOk(/##teamcity\[testStarted/.test(rowToCheck));
 			assert.isOk(/"after each" hook: afterEachHook/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
@@ -69,7 +87,7 @@ describe('Check TeamCity Output is correct with recordHookFailures but with no i
 		});
 
 		it('9 After each hook testFailed', function () {
-			const rowToCheck = teamCityOutputArray[6];
+			const rowToCheck = teamCityOutputArray[8];
 			assert.isOk(/##teamcity\[testFailed/.test(rowToCheck));
 			assert.isOk(/"after each" hook: afterEachHook for "Test Passing Test @pass"'/.test(rowToCheck));
 			assert.isOk(/message='After each hook error fail'/.test(rowToCheck));
@@ -77,16 +95,25 @@ describe('Check TeamCity Output is correct with recordHookFailures but with no i
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
-		it('10 After hook testStarted', function () {
-			const rowToCheck = teamCityOutputArray[7];
+		it('10 After each hook testFinished', function () {
+			const rowToCheck = teamCityOutputArray[9];
+			assert.match(rowToCheck, /##teamcity\[testFinished/);
+			assert.match(rowToCheck, /"after each" hook: afterEachHook/);
+			assert.match(rowToCheck, /flowId=/);
+			assert.match(rowToCheck, /duration=/);
+			assert.match(rowToCheck, /]/);
+		});
+
+		it('11 After hook testStarted', function () {
+			const rowToCheck = teamCityOutputArray[10];
 			assert.isOk(/##teamcity\[testStarted/.test(rowToCheck));
 			assert.isOk(/name='"after all" hook/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
-		it('11 After hook testFailed', function () {
-			const rowToCheck = teamCityOutputArray[8];
+		it('12 After hook testFailed', function () {
+			const rowToCheck = teamCityOutputArray[11];
 			assert.isOk(/##teamcity\[testFailed/.test(rowToCheck));
 			assert.isOk(/"after all" hook: afterHookNoReporting for "Test Passing Test @pass"/.test(rowToCheck));
 			assert.isOk(/message='After hook error fail'/.test(rowToCheck));
@@ -94,8 +121,17 @@ describe('Check TeamCity Output is correct with recordHookFailures but with no i
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
-		it('12 Suite1 testSuiteFinished', function () {
-			const rowToCheck = teamCityOutputArray[9];
+		it('13 After hook testFinished', function () {
+			const rowToCheck = teamCityOutputArray[12];
+			assert.match(rowToCheck, /##teamcity\[testFinished/);
+			assert.match(rowToCheck, /"after all" hook: afterHookNoReporting/);
+			assert.match(rowToCheck, /flowId=/);
+			assert.match(rowToCheck, /duration=/);
+			assert.match(rowToCheck, /]/);
+		});
+
+		it('14 Suite1 testSuiteFinished', function () {
+			const rowToCheck = teamCityOutputArray[13];
 			assert.isOk(/##teamcity\[testSuiteFinished/.test(rowToCheck));
 			assert.isOk(/name='Hook Test Top Describe Fail'/.test(rowToCheck));
 			assert.isOk(/duration=/.test(rowToCheck));
@@ -103,40 +139,58 @@ describe('Check TeamCity Output is correct with recordHookFailures but with no i
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
-		it('13 Suite2 testSuiteStarted', function () {
-			const rowToCheck = teamCityOutputArray[10];
+		it('15 Suite2 testSuiteStarted', function () {
+			const rowToCheck = teamCityOutputArray[14];
 			assert.isOk(/##teamcity\[testSuiteStarted/.test(rowToCheck));
 			assert.isOk(/name='Hook Test Top Describe Pass'/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
-		it('14 Before hook testStarted', function () {
-			const rowToCheck = teamCityOutputArray[11];
+		it('16 Before hook testStarted', function () {
+			const rowToCheck = teamCityOutputArray[15];
 			assert.isOk(/##teamcity\[testStarted/.test(rowToCheck));
 			assert.isOk(/name='"before all" hook/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
-		it('15 Failing test testStarted', function () {
-			const rowToCheck = teamCityOutputArray[12];
+		it('17 Before hook testFinished', function () {
+			const rowToCheck = teamCityOutputArray[16];
+			assert.match(rowToCheck, /##teamcity\[testFinished/);
+			assert.match(rowToCheck, /name='"before all" hook/);
+			assert.match(rowToCheck, /flowId=/);
+			assert.match(rowToCheck, /duration=/);
+			assert.match(rowToCheck, /]/);
+		});
+
+		it('18 Failing test testStarted', function () {
+			const rowToCheck = teamCityOutputArray[17];
 			assert.isOk(/##teamcity\[testStarted/.test(rowToCheck));
 			assert.isOk(/name='Test Failing Test @fail'/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
-		it('16 Before each hook testStarted', function () {
-			const rowToCheck = teamCityOutputArray[13];
+		it('19 Before each hook testStarted', function () {
+			const rowToCheck = teamCityOutputArray[18];
 			assert.isOk(/##teamcity\[testStarted/.test(rowToCheck));
 			assert.isOk(/name='"before each" hook: beforeEachHookNoReporting/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
-		it('17 Failing test testFailed', function () {
-			const rowToCheck = teamCityOutputArray[14];
+		it('20 Before each hook testFinished', function () {
+			const rowToCheck = teamCityOutputArray[19];
+			assert.match(rowToCheck, /##teamcity\[testFinished/);
+			assert.match(rowToCheck, /name='"before each" hook: beforeEachHookNoReporting/);
+			assert.match(rowToCheck, /flowId=/);
+			assert.match(rowToCheck, /duration=/);
+			assert.match(rowToCheck, /]/);
+		});
+
+		it('21 Failing test testFailed', function () {
+			const rowToCheck = teamCityOutputArray[20];
 			assert.isOk(/##teamcity\[testFailed/.test(rowToCheck));
 			assert.isOk(/name='Test Failing Test @fail'/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
@@ -149,8 +203,8 @@ describe('Check TeamCity Output is correct with recordHookFailures but with no i
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
-		it('18 Failing Test testFinished', function () {
-			const rowToCheck = teamCityOutputArray[15];
+		it('22 Failing Test testFinished', function () {
+			const rowToCheck = teamCityOutputArray[21];
 			assert.match(rowToCheck, /##teamcity\[testFinished/);
 			assert.match(rowToCheck, /name='Test Failing Test @fail'/);
 			assert.match(rowToCheck, /flowId=/);
@@ -158,32 +212,50 @@ describe('Check TeamCity Output is correct with recordHookFailures but with no i
 			assert.match(rowToCheck, /]/);
 		});
 
-		it('19 After each hook testStarted', function () {
-			const rowToCheck = teamCityOutputArray[16];
+		it('23 After each hook testStarted', function () {
+			const rowToCheck = teamCityOutputArray[22];
 			assert.isOk(/##teamcity\[testStarted/.test(rowToCheck));
 			assert.isOk(/name='"after each" hook: afterEachHookNoReporting/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
-		it('20 Passing test testStarted', function () {
-			const rowToCheck = teamCityOutputArray[17];
+		it('24 After each hook testFinished', function () {
+			const rowToCheck = teamCityOutputArray[23];
+			assert.match(rowToCheck, /##teamcity\[testFinished/);
+			assert.match(rowToCheck, /name='"after each" hook: afterEachHookNoReporting/);
+			assert.match(rowToCheck, /flowId=/);
+			assert.match(rowToCheck, /duration=/);
+			assert.match(rowToCheck, /]/);
+		});
+
+		it('25 Passing test testStarted', function () {
+			const rowToCheck = teamCityOutputArray[24];
 			assert.isOk(/##teamcity\[testStarted/.test(rowToCheck));
 			assert.isOk(/name='Test Passing Test @pass'/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
-		it('21 Before each hook testStarted', function () {
-			const rowToCheck = teamCityOutputArray[18];
+		it('26 Before each hook testStarted', function () {
+			const rowToCheck = teamCityOutputArray[25];
 			assert.isOk(/##teamcity\[testStarted/.test(rowToCheck));
 			assert.isOk(/name='"before each" hook: beforeEachHookNoReporting/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
-		it('22 Passing test testFinished', function () {
-			const rowToCheck = teamCityOutputArray[19];
+		it('27 Before each hook testFinished', function () {
+			const rowToCheck = teamCityOutputArray[26];
+			assert.match(rowToCheck, /##teamcity\[testFinished/);
+			assert.match(rowToCheck, /"before each" hook: beforeEachHookNoReporting/);
+			assert.match(rowToCheck, /flowId=/);
+			assert.match(rowToCheck, /duration=/);
+			assert.match(rowToCheck, /]/);
+		});
+
+		it('28 Passing test testFinished', function () {
+			const rowToCheck = teamCityOutputArray[27];
 			assert.isOk(/##teamcity\[testFinished/.test(rowToCheck));
 			assert.isOk(/name='Test Passing Test @pass'/.test(rowToCheck));
 			assert.isOk(/duration=/.test(rowToCheck));
@@ -191,24 +263,42 @@ describe('Check TeamCity Output is correct with recordHookFailures but with no i
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
-		it('23 After each hook testStarted', function () {
-			const rowToCheck = teamCityOutputArray[20];
+		it('29 After each hook testStarted', function () {
+			const rowToCheck = teamCityOutputArray[28];
 			assert.isOk(/##teamcity\[testStarted/.test(rowToCheck));
 			assert.isOk(/name='"after each" hook: afterEachHookNoReporting/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
-		it('24 After hook testStarted', function () {
-			const rowToCheck = teamCityOutputArray[21];
+		it('30 After each hook testFinished', function () {
+			const rowToCheck = teamCityOutputArray[29];
+			assert.match(rowToCheck, /##teamcity\[testFinished/);
+			assert.match(rowToCheck, /name='"after each" hook: afterEachHookNoReporting/);
+			assert.match(rowToCheck, /flowId=/);
+			assert.match(rowToCheck, /duration=/);
+			assert.match(rowToCheck, /]/);
+		});
+
+		it('31 After hook testStarted', function () {
+			const rowToCheck = teamCityOutputArray[30];
 			assert.isOk(/##teamcity\[testStarted/.test(rowToCheck));
 			assert.isOk(/name='"after all" hook: afterHook/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
-		it('25 Suite2 Finished', function () {
-			const rowToCheck = teamCityOutputArray[22];
+		it('32 After hook testFinished', function () {
+			const rowToCheck = teamCityOutputArray[31];
+			assert.match(rowToCheck, /##teamcity\[testFinished/);
+			assert.match(rowToCheck, /name='"after all" hook: afterHook/);
+			assert.match(rowToCheck, /flowId=/);
+			assert.match(rowToCheck, /duration=/);
+			assert.match(rowToCheck, /]/);
+		});
+
+		it('33 Suite2 Finished', function () {
+			const rowToCheck = teamCityOutputArray[32];
 			assert.isOk(/##teamcity\[testSuiteFinished/.test(rowToCheck));
 			assert.isOk(/name='Hook Test Top Describe Pass'/.test(rowToCheck));
 			assert.isOk(/duration=/.test(rowToCheck));

--- a/test/functional/ignoreHookWithNameDisabled.js
+++ b/test/functional/ignoreHookWithNameDisabled.js
@@ -55,7 +55,7 @@ describe('Check TeamCity Output is correct with recordHookFailures but with no i
 		it('7 Before each hook testStarted', function () {
 			const rowToCheck = teamCityOutputArray[4];
 			assert.isOk(/##teamcity\[testStarted/.test(rowToCheck));
-			assert.isOk(/name='"before each" hook: beforeEachHookNoReporting/.test(rowToCheck));
+			assert.isOk(/name='"before each" hook: undefinedbeforeEachHookNoReporting/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
 			assert.isOk(/]/.test(rowToCheck));
 		});
@@ -63,7 +63,7 @@ describe('Check TeamCity Output is correct with recordHookFailures but with no i
 		it('8 Before each hook testFailed', function () {
 			const rowToCheck = teamCityOutputArray[5];
 			assert.isOk(/##teamcity\[testFailed/.test(rowToCheck));
-			assert.isOk(/"before each" hook: beforeEachHookNoReporting/.test(rowToCheck));
+			assert.isOk(/"before each" hook: undefinedbeforeEachHookNoReporting/.test(rowToCheck));
 			assert.isOk(/message='Before each hook error fail'/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
 			assert.isOk(/]/.test(rowToCheck));
@@ -72,7 +72,7 @@ describe('Check TeamCity Output is correct with recordHookFailures but with no i
 		it('9 Before all testFinished', function () {
 			const rowToCheck = teamCityOutputArray[6];
 			assert.match(rowToCheck, /##teamcity\[testFinished/);
-			assert.match(rowToCheck, /"before each" hook: beforeEachHookNoReporting/);
+			assert.match(rowToCheck, /"before each" hook: undefinedbeforeEachHookNoReporting/);
 			assert.match(rowToCheck, /flowId=/);
 			assert.match(rowToCheck, /duration=/);
 			assert.match(rowToCheck, /]/);
@@ -81,7 +81,7 @@ describe('Check TeamCity Output is correct with recordHookFailures but with no i
 		it('8 After each hook testStarted', function () {
 			const rowToCheck = teamCityOutputArray[7];
 			assert.isOk(/##teamcity\[testStarted/.test(rowToCheck));
-			assert.isOk(/"after each" hook: afterEachHook/.test(rowToCheck));
+			assert.isOk(/"after each" hook: undefinedafterEachHook/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
 			assert.isOk(/]/.test(rowToCheck));
 		});
@@ -89,7 +89,7 @@ describe('Check TeamCity Output is correct with recordHookFailures but with no i
 		it('9 After each hook testFailed', function () {
 			const rowToCheck = teamCityOutputArray[8];
 			assert.isOk(/##teamcity\[testFailed/.test(rowToCheck));
-			assert.isOk(/"after each" hook: afterEachHook for "Test Passing Test @pass"'/.test(rowToCheck));
+			assert.isOk(/"after each" hook: undefinedafterEachHook for "Test Passing Test @pass"'/.test(rowToCheck));
 			assert.isOk(/message='After each hook error fail'/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
 			assert.isOk(/]/.test(rowToCheck));
@@ -98,7 +98,7 @@ describe('Check TeamCity Output is correct with recordHookFailures but with no i
 		it('10 After each hook testFinished', function () {
 			const rowToCheck = teamCityOutputArray[9];
 			assert.match(rowToCheck, /##teamcity\[testFinished/);
-			assert.match(rowToCheck, /"after each" hook: afterEachHook/);
+			assert.match(rowToCheck, /"after each" hook: undefinedafterEachHook/);
 			assert.match(rowToCheck, /flowId=/);
 			assert.match(rowToCheck, /duration=/);
 			assert.match(rowToCheck, /]/);

--- a/test/functional/ignoreHookWithNameEnabled.js
+++ b/test/functional/ignoreHookWithNameEnabled.js
@@ -55,7 +55,7 @@ describe('Check TeamCity Output is correct with ignoreHookWithName option', func
 		it('7 Before each hook testFailed', function () {
 			const rowToCheck = teamCityOutputArray[4];
 			assert.isOk(/##teamcity\[testFailed/.test(rowToCheck));
-			assert.isOk(/"before each" hook: beforeEachHookNoReporting for "Test Passing Test @pass"'/.test(rowToCheck));
+			assert.isOk(/"before each" hook: undefinedbeforeEachHookNoReporting for "Test Passing Test @pass"'/.test(rowToCheck));
 			assert.isOk(/message='Before each hook error fail'/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
 			assert.isOk(/]/.test(rowToCheck));
@@ -64,7 +64,7 @@ describe('Check TeamCity Output is correct with ignoreHookWithName option', func
 		it('8 After each hook testStarted', function () {
 			const rowToCheck = teamCityOutputArray[5];
 			assert.isOk(/##teamcity\[testStarted/.test(rowToCheck));
-			assert.isOk(/"after each" hook: afterEachHook/.test(rowToCheck));
+			assert.isOk(/"after each" hook: undefinedafterEachHook/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
 			assert.isOk(/]/.test(rowToCheck));
 		});
@@ -72,7 +72,7 @@ describe('Check TeamCity Output is correct with ignoreHookWithName option', func
 		it('8 After each hook testFailed', function () {
 			const rowToCheck = teamCityOutputArray[6];
 			assert.isOk(/##teamcity\[testFailed/.test(rowToCheck));
-			assert.isOk(/"after each" hook: afterEachHook for "Test Passing Test @pass"'/.test(rowToCheck));
+			assert.isOk(/"after each" hook: undefinedafterEachHook for "Test Passing Test @pass"'/.test(rowToCheck));
 			assert.isOk(/message='After each hook error fail'/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
 			assert.isOk(/]/.test(rowToCheck));
@@ -81,7 +81,7 @@ describe('Check TeamCity Output is correct with ignoreHookWithName option', func
 		it('10 After each hook testFinished', function () {
 			const rowToCheck = teamCityOutputArray[7];
 			assert.match(rowToCheck, /##teamcity\[testFinished/);
-			assert.match(rowToCheck, /"after each" hook: afterEachHook/);
+			assert.match(rowToCheck, /"after each" hook: undefinedafterEachHook/);
 			assert.match(rowToCheck, /flowId=/);
 			assert.match(rowToCheck, /duration=/);
 			assert.match(rowToCheck, /]/);

--- a/test/functional/ignoreHookWithNameEnabled.js
+++ b/test/functional/ignoreHookWithNameEnabled.js
@@ -11,8 +11,8 @@ describe('Check TeamCity Output is correct with ignoreHookWithName option', func
 		it('1 stdout output should exist', function () {
 			assert.isOk(teamCityStdout, 'has output');
 			assert.isOk(teamCityOutputArray, 'array of output is populated');
-			assert.lengthOf(teamCityOutputArray, 18);
-			assert.isEmpty(teamCityOutputArray[17]);
+			assert.lengthOf(teamCityOutputArray, 22);
+			assert.isEmpty(teamCityOutputArray[21]);
 		});
 
 		it('2 stderr output should not exist', function () {
@@ -35,16 +35,25 @@ describe('Check TeamCity Output is correct with ignoreHookWithName option', func
 			assert.match(rowToCheck, /]/);
 		});
 
-		it('5 Passing test testStarted', function () {
+		it('5 Before all testFinished', function () {
 			const rowToCheck = teamCityOutputArray[2];
+			assert.match(rowToCheck, /##teamcity\[testFinished/);
+			assert.match(rowToCheck, /name='"before all" hook/);
+			assert.match(rowToCheck, /flowId=/);
+			assert.match(rowToCheck, /duration=/);
+			assert.match(rowToCheck, /]/);
+		});
+
+		it('6 Passing test testStarted', function () {
+			const rowToCheck = teamCityOutputArray[3];
 			assert.isOk(/##teamcity\[testStarted/.test(rowToCheck));
 			assert.isOk(/name='Test Passing Test @pass'/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
-		it('6 Before each hook testFailed', function () {
-			const rowToCheck = teamCityOutputArray[3];
+		it('7 Before each hook testFailed', function () {
+			const rowToCheck = teamCityOutputArray[4];
 			assert.isOk(/##teamcity\[testFailed/.test(rowToCheck));
 			assert.isOk(/"before each" hook: beforeEachHookNoReporting for "Test Passing Test @pass"'/.test(rowToCheck));
 			assert.isOk(/message='Before each hook error fail'/.test(rowToCheck));
@@ -52,8 +61,8 @@ describe('Check TeamCity Output is correct with ignoreHookWithName option', func
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
-		it('7 After each hook testStarted', function () {
-			const rowToCheck = teamCityOutputArray[4];
+		it('8 After each hook testStarted', function () {
+			const rowToCheck = teamCityOutputArray[5];
 			assert.isOk(/##teamcity\[testStarted/.test(rowToCheck));
 			assert.isOk(/"after each" hook: afterEachHook/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
@@ -61,7 +70,7 @@ describe('Check TeamCity Output is correct with ignoreHookWithName option', func
 		});
 
 		it('8 After each hook testFailed', function () {
-			const rowToCheck = teamCityOutputArray[5];
+			const rowToCheck = teamCityOutputArray[6];
 			assert.isOk(/##teamcity\[testFailed/.test(rowToCheck));
 			assert.isOk(/"after each" hook: afterEachHook for "Test Passing Test @pass"'/.test(rowToCheck));
 			assert.isOk(/message='After each hook error fail'/.test(rowToCheck));
@@ -69,8 +78,17 @@ describe('Check TeamCity Output is correct with ignoreHookWithName option', func
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
-		it('9 After hook testFailed', function () {
-			const rowToCheck = teamCityOutputArray[6];
+		it('10 After each hook testFinished', function () {
+			const rowToCheck = teamCityOutputArray[7];
+			assert.match(rowToCheck, /##teamcity\[testFinished/);
+			assert.match(rowToCheck, /"after each" hook: afterEachHook/);
+			assert.match(rowToCheck, /flowId=/);
+			assert.match(rowToCheck, /duration=/);
+			assert.match(rowToCheck, /]/);
+		});
+
+		it('11 After hook testFailed', function () {
+			const rowToCheck = teamCityOutputArray[8];
 			assert.isOk(/##teamcity\[testFailed/.test(rowToCheck));
 			assert.isOk(/"after all" hook: afterHookNoReporting for "Test Passing Test @pass"/.test(rowToCheck));
 			assert.isOk(/message='After hook error fail'/.test(rowToCheck));
@@ -78,8 +96,8 @@ describe('Check TeamCity Output is correct with ignoreHookWithName option', func
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
-		it('10 Suite1 testSuiteFinished', function () {
-			const rowToCheck = teamCityOutputArray[7];
+		it('12 Suite1 testSuiteFinished', function () {
+			const rowToCheck = teamCityOutputArray[9];
 			assert.isOk(/##teamcity\[testSuiteFinished/.test(rowToCheck));
 			assert.isOk(/name='Hook Test Top Describe Fail'/.test(rowToCheck));
 			assert.isOk(/duration=/.test(rowToCheck));
@@ -87,32 +105,41 @@ describe('Check TeamCity Output is correct with ignoreHookWithName option', func
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
-		it('11 Suite2 testSuiteStarted', function () {
-			const rowToCheck = teamCityOutputArray[8];
+		it('13 Suite2 testSuiteStarted', function () {
+			const rowToCheck = teamCityOutputArray[10];
 			assert.isOk(/##teamcity\[testSuiteStarted/.test(rowToCheck));
 			assert.isOk(/name='Hook Test Top Describe Pass'/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
-		it('12 Before hook testStarted', function () {
-			const rowToCheck = teamCityOutputArray[9];
+		it('14 Before hook testStarted', function () {
+			const rowToCheck = teamCityOutputArray[11];
 			assert.isOk(/##teamcity\[testStarted/.test(rowToCheck));
 			assert.isOk(/name='"before all" hook/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
-		it('13 Failing test testStarted', function () {
-			const rowToCheck = teamCityOutputArray[10];
+		it('15 Before hook testFinished', function () {
+			const rowToCheck = teamCityOutputArray[12];
+			assert.match(rowToCheck, /##teamcity\[testFinished/);
+			assert.match(rowToCheck, /name='"before all" hook/);
+			assert.match(rowToCheck, /flowId=/);
+			assert.match(rowToCheck, /duration=/);
+			assert.match(rowToCheck, /]/);
+		});
+
+		it('16 Failing test testStarted', function () {
+			const rowToCheck = teamCityOutputArray[13];
 			assert.isOk(/##teamcity\[testStarted/.test(rowToCheck));
 			assert.isOk(/name='Test Failing Test @fail'/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
-		it('14 Failing test testFailed', function () {
-			const rowToCheck = teamCityOutputArray[11];
+		it('17 Failing test testFailed', function () {
+			const rowToCheck = teamCityOutputArray[14];
 			assert.isOk(/##teamcity\[testFailed/.test(rowToCheck));
 			assert.isOk(/name='Test Failing Test @fail'/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
@@ -125,8 +152,8 @@ describe('Check TeamCity Output is correct with ignoreHookWithName option', func
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
-		it('15 Failing Test testFinished', function () {
-			const rowToCheck = teamCityOutputArray[12];
+		it('18 Failing Test testFinished', function () {
+			const rowToCheck = teamCityOutputArray[15];
 			assert.match(rowToCheck, /##teamcity\[testFinished/);
 			assert.match(rowToCheck, /name='Test Failing Test @fail'/);
 			assert.match(rowToCheck, /flowId=/);
@@ -134,16 +161,16 @@ describe('Check TeamCity Output is correct with ignoreHookWithName option', func
 			assert.match(rowToCheck, /]/);
 		});
 
-		it('16 Passing test testStarted', function () {
-			const rowToCheck = teamCityOutputArray[13];
+		it('19 Passing test testStarted', function () {
+			const rowToCheck = teamCityOutputArray[16];
 			assert.isOk(/##teamcity\[testStarted/.test(rowToCheck));
 			assert.isOk(/name='Test Passing Test @pass'/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
-		it('17 Passing test testFinished', function () {
-			const rowToCheck = teamCityOutputArray[14];
+		it('20 Passing test testFinished', function () {
+			const rowToCheck = teamCityOutputArray[17];
 			assert.isOk(/##teamcity\[testFinished/.test(rowToCheck));
 			assert.isOk(/name='Test Passing Test @pass'/.test(rowToCheck));
 			assert.isOk(/duration=/.test(rowToCheck));
@@ -151,16 +178,25 @@ describe('Check TeamCity Output is correct with ignoreHookWithName option', func
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
-		it('18 After hook testStarted', function () {
-			const rowToCheck = teamCityOutputArray[15];
+		it('21 After hook testStarted', function () {
+			const rowToCheck = teamCityOutputArray[18];
 			assert.isOk(/##teamcity\[testStarted/.test(rowToCheck));
 			assert.isOk(/name='"after all" hook: afterHook/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
+		it('22 After hook testFinished', function () {
+			const rowToCheck = teamCityOutputArray[19];
+			assert.match(rowToCheck, /##teamcity\[testFinished/);
+			assert.match(rowToCheck, /name='"after all" hook: afterHook/);
+			assert.match(rowToCheck, /flowId=/);
+			assert.match(rowToCheck, /duration=/);
+			assert.match(rowToCheck, /]/);
+		});
+
 		it('19 Suite2 Finished is OK', function () {
-			const rowToCheck = teamCityOutputArray[16];
+			const rowToCheck = teamCityOutputArray[20];
 			assert.isOk(/##teamcity\[testSuiteFinished/.test(rowToCheck));
 			assert.isOk(/name='Hook Test Top Describe Pass'/.test(rowToCheck));
 			assert.isOk(/duration=/.test(rowToCheck));

--- a/test/functional/recordHookFailures.js
+++ b/test/functional/recordHookFailures.js
@@ -11,8 +11,8 @@ describe('Check TeamCity Output is correct with recordHookFailures option', func
 		it('stdout output should exist', function () {
 			assert.isOk(teamCityStdout, 'has output');
 			assert.isOk(teamCityOutputArray, 'array of output is populated');
-			assert.lengthOf(teamCityOutputArray, 13);
-			assert.isEmpty(teamCityOutputArray[12]);
+			assert.lengthOf(teamCityOutputArray, 15);
+			assert.isEmpty(teamCityOutputArray[14]);
 		});
 
 		it('stderr output should not exist', function () {
@@ -56,8 +56,17 @@ describe('Check TeamCity Output is correct with recordHookFailures option', func
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
-		it('Suite1 Finished is OK', function () {
+		it('Hook Test Finished for failed hook is OK', function () {
 			const rowToCheck = teamCityOutputArray[3];
+			assert.isOk(/##teamcity\[testFinished/.test(rowToCheck));
+			assert.isOk(/name='"before all" hook/.test(rowToCheck));
+			assert.isOk(/flowId=/.test(rowToCheck));
+			assert.isOk(/duration=/.test(rowToCheck));
+			assert.isOk(/]/.test(rowToCheck));
+		});
+
+		it('Suite1 Finished is OK', function () {
+			const rowToCheck = teamCityOutputArray[4];
 			assert.isOk(/##teamcity\[testSuiteFinished/.test(rowToCheck));
 			assert.isOk(/name='Hook Test Top Describe Fail'/.test(rowToCheck));
 			assert.isOk(/duration=/.test(rowToCheck));
@@ -66,7 +75,7 @@ describe('Check TeamCity Output is correct with recordHookFailures option', func
 		});
 
 		it('Suite2 started is OK', function () {
-			const rowToCheck = teamCityOutputArray[4];
+			const rowToCheck = teamCityOutputArray[5];
 			assert.isOk(/##teamcity\[testSuiteStarted/.test(rowToCheck));
 			assert.isOk(/name='Hook Test Top Describe Pass'/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
@@ -75,7 +84,7 @@ describe('Check TeamCity Output is correct with recordHookFailures option', func
 
 
 		it('Test started is OK', function () {
-			const rowToCheck = teamCityOutputArray[9];
+			const rowToCheck = teamCityOutputArray[11];
 			assert.isOk(/##teamcity\[testStarted/.test(rowToCheck));
 			assert.isOk(/name='Test Passing Test @pass'/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
@@ -84,7 +93,7 @@ describe('Check TeamCity Output is correct with recordHookFailures option', func
 
 
 		it('Passing Test Finished is OK', function () {
-			const rowToCheck = teamCityOutputArray[10];
+			const rowToCheck = teamCityOutputArray[12];
 			assert.isOk(/##teamcity\[testFinished/.test(rowToCheck));
 			assert.isOk(/name='Test Passing Test @pass'/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
@@ -92,8 +101,25 @@ describe('Check TeamCity Output is correct with recordHookFailures option', func
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
-		it('Test Failed is Failing', function () {
+		it('Hook Test Started for failed hook is OK', function () {
+			const rowToCheck = teamCityOutputArray[6];
+			assert.isOk(/##teamcity\[testStarted/.test(rowToCheck));
+			assert.isOk(/name='"before all" hook/.test(rowToCheck));
+			assert.isOk(/flowId=/.test(rowToCheck));
+			assert.isOk(/]/.test(rowToCheck));
+		});
+
+		it('Hook Test Finished for hook is OK', function () {
 			const rowToCheck = teamCityOutputArray[7];
+			assert.isOk(/##teamcity\[testFinished/.test(rowToCheck));
+			assert.isOk(/name='"before all" hook/.test(rowToCheck));
+			assert.isOk(/flowId=/.test(rowToCheck));
+			assert.isOk(/duration=/.test(rowToCheck));
+			assert.isOk(/]/.test(rowToCheck));
+		});
+
+		it('Test Failed is Failing', function () {
+			const rowToCheck = teamCityOutputArray[9];
 			assert.isOk(/##teamcity\[testFailed/.test(rowToCheck));
 			assert.isOk(/name='Test Failing Test @fail'/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
@@ -107,7 +133,7 @@ describe('Check TeamCity Output is correct with recordHookFailures option', func
 		});
 
 		it('Failing Test Finished is OK', function () {
-			const rowToCheck = teamCityOutputArray[8];
+			const rowToCheck = teamCityOutputArray[10];
 			assert.match(rowToCheck, /##teamcity\[testFinished/);
 			assert.match(rowToCheck, /name='Test Failing Test @fail'/);
 			assert.match(rowToCheck, /flowId=/);
@@ -116,7 +142,7 @@ describe('Check TeamCity Output is correct with recordHookFailures option', func
 		});
 
 		it('Suite2 Finished is OK', function () {
-			const rowToCheck = teamCityOutputArray[11];
+			const rowToCheck = teamCityOutputArray[13];
 			assert.isOk(/##teamcity\[testSuiteFinished/.test(rowToCheck));
 			assert.isOk(/name='Hook Test Top Describe Pass'/.test(rowToCheck));
 			assert.isOk(/duration=/.test(rowToCheck));
@@ -125,7 +151,7 @@ describe('Check TeamCity Output is correct with recordHookFailures option', func
 		});
 
 		it('Suite Root Finished is OK', function () {
-			const rowToCheck = teamCityOutputArray[11];
+			const rowToCheck = teamCityOutputArray[13];
 			assert.isOk(/##teamcity\[testSuiteFinished/.test(rowToCheck));
 			assert.isNotOk(/name='mocha.suite'/.test(rowToCheck));
 			assert.isOk(/duration=/.test(rowToCheck));


### PR DESCRIPTION
## Proposed changes
This pull request is created to address problem from the issue https://github.com/travisjeffery/mocha-teamcity-reporter/issues/54.
This change is a bit hacky for the case when hook failed because it looks like mocha does not fire `hook end` event if hook failed.

This change affects only a case when a report option `recordHookFailures` is set to true.

## Types of changes

What types of changes does your code introduce
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
