### PR TITLE
Bugfix/issue 61

### DIFF
--- a/lib/teamcity.js
+++ b/lib/teamcity.js
@@ -88,6 +88,8 @@ function Teamcity(runner, options) {
 	let stats = this.stats;
 	const topLevelSuite = reporterOptions.topLevelSuite || process.env['MOCHA_TEAMCITY_TOP_LEVEL_SUITE'];
 
+	const hookFlowId = `${flowId}_hook`;
+
 	runner.on('suite', function (suite) {
 		if (suite.root) {
 			if (topLevelSuite) {
@@ -104,30 +106,36 @@ function Teamcity(runner, options) {
 	});
 
 	runner.on('fail', function (test, err) {
+		let isHook = false;
+		if (test.title.includes(`"before all" hook`) ||
+			test.title.includes(`"before each" hook`) ||
+			test.title.includes(`"after all" hook`) ||
+			test.title.includes(`"after each" hook`)
+		) {
+			isHook = true;
+		}
+
+		const testFlowId = (isHook) ? hookFlowId : flowId;
 		if(actualVsExpected && (err.actual && err.expected)){
 			if (useStdError) {
-				logError(formatString(TEST_FAILED_COMPARISON, test.title, err.message, err.stack, err.actual, err.expected, flowId));
+				logError(formatString(TEST_FAILED_COMPARISON, test.title, err.message, err.stack, err.actual, err.expected, testFlowId));
 			} else {
-				log(formatString(TEST_FAILED_COMPARISON, test.title, err.message, err.stack, err.actual, err.expected, flowId));
+				log(formatString(TEST_FAILED_COMPARISON, test.title, err.message, err.stack, err.actual, err.expected, testFlowId));
 			}
 		} else{
 			if (useStdError) {
-				logError(formatString(TEST_FAILED, test.title, err.message, err.stack, flowId));
+				logError(formatString(TEST_FAILED, test.title, err.message, err.stack, testFlowId));
 			} else {
-				log(formatString(TEST_FAILED, test.title, err.message, err.stack, flowId));
+				log(formatString(TEST_FAILED, test.title, err.message, err.stack, testFlowId));
 			}
 		}
 		// Log testFinished for failed hook (hook end event is not fired for failed hook)
 		if (recordHookFailures && !ignoreHookWithName || recordHookFailures && ignoreHookWithName && !test.title.includes(ignoreHookWithName)) {
-			if (test.title.includes(`"before all" hook`)
-					|| test.title.includes(`"before each" hook`) 
-					|| test.title.includes(`"after all" hook`)
-					|| test.title.includes(`"after each" hook`)
-				) {
+			if (isHook) {
 				if(isNil(test.duration)){
-					log(formatString(TEST_END_NO_DURATION, test.title, flowId));
+					log(formatString(TEST_END_NO_DURATION, test.title, hookFlowId));
 				} else {
-					log(formatString(TEST_END, test.title, test.duration.toString(), flowId));
+					log(formatString(TEST_END, test.title, test.duration.toString(), hookFlowId));
 				}
 			}
 		}
@@ -147,16 +155,16 @@ function Teamcity(runner, options) {
 
 	runner.on('hook', function (test) {
 		if (recordHookFailures && !ignoreHookWithName || recordHookFailures && ignoreHookWithName && !test.title.includes(ignoreHookWithName)) {
-			log(formatString(TEST_START, test.title, flowId));
+			log(formatString(TEST_START, test.title, hookFlowId));
 		}
 	});
 
 	runner.on('hook end', function (test) {
 		if (recordHookFailures && !ignoreHookWithName || recordHookFailures && ignoreHookWithName && !test.title.includes(ignoreHookWithName)) {
 			if(isNil(test.duration)){
-				log(formatString(TEST_END_NO_DURATION, test.title, flowId));
+				log(formatString(TEST_END_NO_DURATION, test.title, hookFlowId));
 			} else {
-				log(formatString(TEST_END, test.title, test.duration.toString(), flowId));
+				log(formatString(TEST_END, test.title, test.duration.toString(), hookFlowId));
 			}
 		}
 	});

--- a/test/functional/recordHookFailuresDisabled.js
+++ b/test/functional/recordHookFailuresDisabled.js
@@ -5,45 +5,31 @@ const { logMochaOutput, getMochaPath } = require('../testHelpers');
 const internalMochaPath = getMochaPath();
 const path = require('path');
 
-describe('Check TeamCity Output is correct with recordHookFailures option', function () {
+describe('Check TeamCity Output is correct with recordHookFailures option disabled', function () {
 	let teamCityStdout, teamCityStderr, teamCityOutputArray;
 	function verifyResults() {
-		it('stdout output should exist', function () {
+		it('1 stdout output should exist', function () {
 			assert.isOk(teamCityStdout, 'has output');
 			assert.isOk(teamCityOutputArray, 'array of output is populated');
-			assert.lengthOf(teamCityOutputArray, 15);
-			assert.isEmpty(teamCityOutputArray[14]);
+			assert.lengthOf(teamCityOutputArray, 11);
+			assert.isEmpty(teamCityOutputArray[10]);
 		});
 
-		it('stderr output should not exist', function () {
+		it('2 stderr output should not exist', function () {
 			assert.isEmpty(teamCityStderr);
 		});
 
-
-		it('stdout output should exist', function () {
-			assert.isOk(teamCityStdout);
-			assert.isOk(teamCityOutputArray);
-			assert.isOk(teamCityOutputArray.length >= 12);
-		});
-
-		it('Suite1 started is OK', function () {
+		it('3 testSuiteStarted for Suite1', function () {
 			const rowToCheck = teamCityOutputArray[0];
 			assert.isOk(/##teamcity\[testSuiteStarted/.test(rowToCheck));
 			assert.isOk(/name='Hook Test Top Describe Fail'/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
+			assert.notMatch(rowToCheck, /flowId=.*_hook/);
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
-		it('Hook Test started is OK', function () {
+		it('4 testFailed for before all hook', function () {
 			const rowToCheck = teamCityOutputArray[1];
-			assert.match(rowToCheck, /##teamcity\[testStarted/);
-			assert.match(rowToCheck, /name='"before all" hook/);
-			assert.match(rowToCheck, /flowId=/);
-			assert.match(rowToCheck, /]/);
-		});
-
-		it('Hook Test Failed is OK', function () {
-			const rowToCheck = teamCityOutputArray[2];
 			assert.isOk(/##teamcity\[testFailed/.test(rowToCheck));
 			assert.isOk(/name='"before all" hook/.test(rowToCheck));
 			assert.isOk(/details='/.test(rowToCheck));
@@ -51,78 +37,45 @@ describe('Check TeamCity Output is correct with recordHookFailures option', func
 			assert.isOk(/|n/.test(rowToCheck));
 			assert.isOk(/|failingHook.js:29:12/.test(rowToCheck));
 			assert.isOk(/captureStandardOutput='true'/.test(rowToCheck));
-			assert.isOk(/flowId=/.test(rowToCheck));
+			assert.match(rowToCheck, /flowId=.*_hook/);
 			assert.isOk(/duration=/.test(rowToCheck) === false);
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
-		it('Hook Test Finished for failed hook is OK', function () {
-			const rowToCheck = teamCityOutputArray[3];
-			assert.isOk(/##teamcity\[testFinished/.test(rowToCheck));
-			assert.isOk(/name='"before all" hook/.test(rowToCheck));
-			assert.isOk(/flowId=/.test(rowToCheck));
-			assert.isOk(/duration=/.test(rowToCheck));
-			assert.isOk(/]/.test(rowToCheck));
-		});
-
-		it('Suite1 Finished is OK', function () {
-			const rowToCheck = teamCityOutputArray[4];
+		it('5 testSuiteFinished for Suite1', function () {
+			const rowToCheck = teamCityOutputArray[2];
 			assert.isOk(/##teamcity\[testSuiteFinished/.test(rowToCheck));
 			assert.isOk(/name='Hook Test Top Describe Fail'/.test(rowToCheck));
 			assert.isOk(/duration=/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
+			assert.notMatch(rowToCheck, /flowId=.*_hook/);
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
-		it('Suite2 started is OK', function () {
-			const rowToCheck = teamCityOutputArray[5];
+		it('6 testSuiteStarted for Suite2', function () {
+			const rowToCheck = teamCityOutputArray[3];
 			assert.isOk(/##teamcity\[testSuiteStarted/.test(rowToCheck));
 			assert.isOk(/name='Hook Test Top Describe Pass'/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
+			assert.notMatch(rowToCheck, /flowId=.*_hook/);
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
-
-		it('Test started is OK', function () {
-			const rowToCheck = teamCityOutputArray[11];
+		it('7 testStarted for Failing Test', function () {
+			const rowToCheck = teamCityOutputArray[4];
 			assert.isOk(/##teamcity\[testStarted/.test(rowToCheck));
-			assert.isOk(/name='Test Passing Test @pass'/.test(rowToCheck));
+			assert.isOk(/name='Test Failing Test @fail'/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
+			assert.notMatch(rowToCheck, /flowId=.*_hook/);
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
-
-		it('Passing Test Finished is OK', function () {
-			const rowToCheck = teamCityOutputArray[12];
-			assert.isOk(/##teamcity\[testFinished/.test(rowToCheck));
-			assert.isOk(/name='Test Passing Test @pass'/.test(rowToCheck));
-			assert.isOk(/flowId=/.test(rowToCheck));
-			assert.isOk(/duration=/.test(rowToCheck));
-			assert.isOk(/]/.test(rowToCheck));
-		});
-
-		it('Hook Test Started for failed hook is OK', function () {
-			const rowToCheck = teamCityOutputArray[6];
-			assert.isOk(/##teamcity\[testStarted/.test(rowToCheck));
-			assert.isOk(/name='"before all" hook/.test(rowToCheck));
-			assert.isOk(/flowId=/.test(rowToCheck));
-			assert.isOk(/]/.test(rowToCheck));
-		});
-
-		it('Hook Test Finished for hook is OK', function () {
-			const rowToCheck = teamCityOutputArray[7];
-			assert.isOk(/##teamcity\[testFinished/.test(rowToCheck));
-			assert.isOk(/name='"before all" hook/.test(rowToCheck));
-			assert.isOk(/flowId=/.test(rowToCheck));
-			assert.isOk(/duration=/.test(rowToCheck));
-			assert.isOk(/]/.test(rowToCheck));
-		});
-
-		it('Test Failed is Failing', function () {
-			const rowToCheck = teamCityOutputArray[9];
+		it('8 testFailed for Failing Test', function () {
+			const rowToCheck = teamCityOutputArray[5];
 			assert.isOk(/##teamcity\[testFailed/.test(rowToCheck));
 			assert.isOk(/name='Test Failing Test @fail'/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
+			assert.notMatch(rowToCheck, /flowId=.*_hook/);
 			assert.isOk(/duration=/.test(rowToCheck) === false);
 			assert.isOk(/details='/.test(rowToCheck));
 			assert.isOk(/AssertionError/.test(rowToCheck));
@@ -132,8 +85,8 @@ describe('Check TeamCity Output is correct with recordHookFailures option', func
 			assert.isOk(/]/.test(rowToCheck));
 		});
 
-		it('Failing Test Finished is OK', function () {
-			const rowToCheck = teamCityOutputArray[10];
+		it('9 testFinished for Failing Test', function () {
+			const rowToCheck = teamCityOutputArray[6];
 			assert.match(rowToCheck, /##teamcity\[testFinished/);
 			assert.match(rowToCheck, /name='Test Failing Test @fail'/);
 			assert.match(rowToCheck, /flowId=/);
@@ -141,32 +94,40 @@ describe('Check TeamCity Output is correct with recordHookFailures option', func
 			assert.match(rowToCheck, /]/);
 		});
 
-		it('Suite2 Finished is OK', function () {
-			const rowToCheck = teamCityOutputArray[13];
+		it('10 testStarted for Passing Test', function () {
+			const rowToCheck = teamCityOutputArray[7];
+			assert.isOk(/##teamcity\[testStarted/.test(rowToCheck));
+			assert.isOk(/name='Test Passing Test @pass'/.test(rowToCheck));
+			assert.isOk(/flowId=/.test(rowToCheck));
+			assert.notMatch(rowToCheck, /flowId=.*_hook/);
+			assert.isOk(/]/.test(rowToCheck));
+		});
+
+
+		it('11 testFinished for Passing Test', function () {
+			const rowToCheck = teamCityOutputArray[8];
+			assert.isOk(/##teamcity\[testFinished/.test(rowToCheck));
+			assert.isOk(/name='Test Passing Test @pass'/.test(rowToCheck));
+			assert.isOk(/flowId=/.test(rowToCheck));
+			assert.notMatch(rowToCheck, /flowId=.*_hook/);
+			assert.isOk(/duration=/.test(rowToCheck));
+			assert.isOk(/]/.test(rowToCheck));
+		});
+
+		it('12 testSuiteFinished for Suite2', function () {
+			const rowToCheck = teamCityOutputArray[9];
 			assert.isOk(/##teamcity\[testSuiteFinished/.test(rowToCheck));
 			assert.isOk(/name='Hook Test Top Describe Pass'/.test(rowToCheck));
 			assert.isOk(/duration=/.test(rowToCheck));
 			assert.isOk(/flowId=/.test(rowToCheck));
-			assert.isOk(/]/.test(rowToCheck));
-		});
-
-		it('Suite Root Finished is OK', function () {
-			const rowToCheck = teamCityOutputArray[13];
-			assert.isOk(/##teamcity\[testSuiteFinished/.test(rowToCheck));
-			assert.isNotOk(/name='mocha.suite'/.test(rowToCheck));
-			assert.isOk(/duration=/.test(rowToCheck));
-			assert.isOk(/flowId=/.test(rowToCheck));
+			assert.notMatch(rowToCheck, /flowId=.*_hook/);
 			assert.isOk(/]/.test(rowToCheck));
 		});
 	}
 
 	describe('specified as an env var', function () {
 		before(function (done) {
-			const opts = {
-				env: Object.assign({
-					['RECORD_HOOK_FAILURES']: 'true'
-				}, process.env)
-			};
+			const opts = {};
 
 			execFile(internalMochaPath, [
 				'test/example/failingHook.js',
@@ -188,9 +149,7 @@ describe('Check TeamCity Output is correct with recordHookFailures option', func
 			execFile(internalMochaPath, [
 				path.join('test', 'example', 'failingHook.js'),
 				'--reporter',
-				'lib/teamcity',
-				'--reporter-options',
-				'recordHookFailures=true'
+				'lib/teamcity'
 			], (err, stdout, stderr) => {
 				teamCityStdout = stdout;
 				teamCityStderr = stderr;

--- a/test/functional/recordHookFailuresEnabled.js
+++ b/test/functional/recordHookFailuresEnabled.js
@@ -1,0 +1,203 @@
+'use strict';
+const {execFile} = require('child_process');
+const {assert} = require('chai');
+const { logMochaOutput, getMochaPath } = require('../testHelpers');
+const internalMochaPath = getMochaPath();
+const path = require('path');
+
+describe('Check TeamCity Output is correct with recordHookFailures option', function () {
+	let teamCityStdout, teamCityStderr, teamCityOutputArray;
+	function verifyResults() {
+		it('1 stdout output should exist', function () {
+			assert.isOk(teamCityStdout, 'has output');
+			assert.isOk(teamCityOutputArray, 'array of output is populated');
+			assert.lengthOf(teamCityOutputArray, 15);
+			assert.isEmpty(teamCityOutputArray[14]);
+		});
+
+		it('2 stderr output should not exist', function () {
+			assert.isEmpty(teamCityStderr);
+		});
+
+		it('3 testSuiteStarted for Suite1', function () {
+			const rowToCheck = teamCityOutputArray[0];
+			assert.isOk(/##teamcity\[testSuiteStarted/.test(rowToCheck));
+			assert.isOk(/name='Hook Test Top Describe Fail'/.test(rowToCheck));
+			assert.isOk(/flowId=/.test(rowToCheck));
+			assert.notMatch(rowToCheck, /flowId=.*_hook/);
+			assert.isOk(/]/.test(rowToCheck));
+		});
+
+		it('4 testStarted for before all hook', function () {
+			const rowToCheck = teamCityOutputArray[1];
+			assert.match(rowToCheck, /##teamcity\[testStarted/);
+			assert.match(rowToCheck, /name='"before all" hook/);
+			assert.match(rowToCheck, /flowId=.*_hook/);
+			assert.match(rowToCheck, /]/);
+		});
+
+		it('5 testFailed for before all hook', function () {
+			const rowToCheck = teamCityOutputArray[2];
+			assert.isOk(/##teamcity\[testFailed/.test(rowToCheck));
+			assert.isOk(/name='"before all" hook/.test(rowToCheck));
+			assert.isOk(/details='/.test(rowToCheck));
+			assert.isOk(/Error: Before hook error fail/.test(rowToCheck));
+			assert.isOk(/|n/.test(rowToCheck));
+			assert.isOk(/|failingHook.js:29:12/.test(rowToCheck));
+			assert.isOk(/captureStandardOutput='true'/.test(rowToCheck));
+			assert.match(rowToCheck, /flowId=.*_hook/);
+			assert.isOk(/duration=/.test(rowToCheck) === false);
+			assert.isOk(/]/.test(rowToCheck));
+		});
+
+		it('6 Hook testFinished for before all hook', function () {
+			const rowToCheck = teamCityOutputArray[3];
+			assert.isOk(/##teamcity\[testFinished/.test(rowToCheck));
+			assert.isOk(/name='"before all" hook/.test(rowToCheck));
+			assert.match(rowToCheck, /flowId=.*_hook/);
+			assert.isOk(/duration=/.test(rowToCheck));
+			assert.isOk(/]/.test(rowToCheck));
+		});
+
+		it('7 testSuiteFinished for Suite1', function () {
+			const rowToCheck = teamCityOutputArray[4];
+			assert.isOk(/##teamcity\[testSuiteFinished/.test(rowToCheck));
+			assert.isOk(/name='Hook Test Top Describe Fail'/.test(rowToCheck));
+			assert.isOk(/duration=/.test(rowToCheck));
+			assert.isOk(/flowId=/.test(rowToCheck));
+			assert.notMatch(rowToCheck, /flowId=.*_hook/);
+			assert.isOk(/]/.test(rowToCheck));
+		});
+
+		it('8 testSuiteStarted for Suite2', function () {
+			const rowToCheck = teamCityOutputArray[5];
+			assert.isOk(/##teamcity\[testSuiteStarted/.test(rowToCheck));
+			assert.isOk(/name='Hook Test Top Describe Pass'/.test(rowToCheck));
+			assert.isOk(/flowId=/.test(rowToCheck));
+			assert.notMatch(rowToCheck, /flowId=.*_hook/);
+			assert.isOk(/]/.test(rowToCheck));
+		});
+
+		it('9 testStarted for before all hook', function () {
+			const rowToCheck = teamCityOutputArray[6];
+			assert.isOk(/##teamcity\[testStarted/.test(rowToCheck));
+			assert.isOk(/name='"before all" hook/.test(rowToCheck));
+			assert.match(rowToCheck, /flowId=.*_hook/);
+			assert.isOk(/]/.test(rowToCheck));
+		});
+
+		it('10 Hook testFinished for before all hook', function () {
+			const rowToCheck = teamCityOutputArray[7];
+			assert.isOk(/##teamcity\[testFinished/.test(rowToCheck));
+			assert.isOk(/name='"before all" hook/.test(rowToCheck));
+			assert.match(rowToCheck, /flowId=.*_hook/);
+			assert.isOk(/duration=/.test(rowToCheck));
+			assert.isOk(/]/.test(rowToCheck));
+		});
+
+		it('11 testStarted for Failing Test', function () {
+			const rowToCheck = teamCityOutputArray[8];
+			assert.isOk(/##teamcity\[testStarted/.test(rowToCheck));
+			assert.isOk(/name='Test Failing Test @fail'/.test(rowToCheck));
+			assert.isOk(/flowId=/.test(rowToCheck));
+			assert.notMatch(rowToCheck, /flowId=.*_hook/);
+			assert.isOk(/]/.test(rowToCheck));
+		});
+
+		it('12 testFailed for Failing Test', function () {
+			const rowToCheck = teamCityOutputArray[9];
+			assert.isOk(/##teamcity\[testFailed/.test(rowToCheck));
+			assert.isOk(/name='Test Failing Test @fail'/.test(rowToCheck));
+			assert.isOk(/flowId=/.test(rowToCheck));
+			assert.notMatch(rowToCheck, /flowId=.*_hook/);
+			assert.isOk(/duration=/.test(rowToCheck) === false);
+			assert.isOk(/details='/.test(rowToCheck));
+			assert.isOk(/AssertionError/.test(rowToCheck));
+			assert.isOk(/|n/.test(rowToCheck));
+			assert.isOk(/|failingHook.js:29:12/.test(rowToCheck));
+			assert.isOk(/captureStandardOutput='true'/.test(rowToCheck));
+			assert.isOk(/]/.test(rowToCheck));
+		});
+
+		it('13 testFinished for Failing Test', function () {
+			const rowToCheck = teamCityOutputArray[10];
+			assert.match(rowToCheck, /##teamcity\[testFinished/);
+			assert.match(rowToCheck, /name='Test Failing Test @fail'/);
+			assert.match(rowToCheck, /flowId=/);
+			assert.match(rowToCheck, /duration=/);
+			assert.match(rowToCheck, /]/);
+		});
+
+		it('14 testStarted for Passing Test', function () {
+			const rowToCheck = teamCityOutputArray[11];
+			assert.isOk(/##teamcity\[testStarted/.test(rowToCheck));
+			assert.isOk(/name='Test Passing Test @pass'/.test(rowToCheck));
+			assert.isOk(/flowId=/.test(rowToCheck));
+			assert.notMatch(rowToCheck, /flowId=.*_hook/);
+			assert.isOk(/]/.test(rowToCheck));
+		});
+
+
+		it('15 testFinished for Passing Test', function () {
+			const rowToCheck = teamCityOutputArray[12];
+			assert.isOk(/##teamcity\[testFinished/.test(rowToCheck));
+			assert.isOk(/name='Test Passing Test @pass'/.test(rowToCheck));
+			assert.isOk(/flowId=/.test(rowToCheck));
+			assert.notMatch(rowToCheck, /flowId=.*_hook/);
+			assert.isOk(/duration=/.test(rowToCheck));
+			assert.isOk(/]/.test(rowToCheck));
+		});
+
+		it('16 testSuiteFinished for Suite2', function () {
+			const rowToCheck = teamCityOutputArray[13];
+			assert.isOk(/##teamcity\[testSuiteFinished/.test(rowToCheck));
+			assert.isOk(/name='Hook Test Top Describe Pass'/.test(rowToCheck));
+			assert.isOk(/duration=/.test(rowToCheck));
+			assert.isOk(/flowId=/.test(rowToCheck));
+			assert.notMatch(rowToCheck, /flowId=.*_hook/);
+			assert.isOk(/]/.test(rowToCheck));
+		});
+	}
+
+	describe('specified as an env var', function () {
+		before(function (done) {
+			const opts = {
+				env: Object.assign({
+					['RECORD_HOOK_FAILURES']: 'true'
+				}, process.env)
+			};
+
+			execFile(internalMochaPath, [
+				'test/example/failingHook.js',
+				'--reporter',
+				'lib/teamcity'
+			], opts, (err, stdout, stderr) => {
+				teamCityStdout = stdout;
+				teamCityStderr = stderr;
+				teamCityOutputArray = stdout.split('\n');
+				logMochaOutput(stdout, stderr);
+				done();
+			});
+		});
+		verifyResults();
+	});
+
+	describe('specified with --reporter-options', function () {
+		before(function (done) {
+			execFile(internalMochaPath, [
+				path.join('test', 'example', 'failingHook.js'),
+				'--reporter',
+				'lib/teamcity',
+				'--reporter-options',
+				'recordHookFailures=true'
+			], (err, stdout, stderr) => {
+				teamCityStdout = stdout;
+				teamCityStderr = stderr;
+				teamCityOutputArray = stdout.split('\n');
+				logMochaOutput(stdout, stderr);
+				done();
+			});
+		});
+		verifyResults();
+	});
+});


### PR DESCRIPTION
## Proposed changes
This PR contains fix for issue https://github.com/travisjeffery/mocha-teamcity-reporter/issues/61

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments
Issue was caused by the same flowId for tests and hooks. In the example below you can see that all 5 lines have the same flowId. So test that was started on the 1st line is treated as finished successfully once the second line is parsed because of the TC logic:
(Quote from [TC doc](https://www.jetbrains.com/help/teamcity/service-messages.html#Nested+test+reporting)):
_Starting another test finishes the currently started test in the same flow. To still report tests from within other tests, you will need to specify another flowId in the nested test service messages._

```
##teamcity[testStarted name='Test' captureStandardOutput='true' flowId='19']
##teamcity[testStarted name='"before each" hook' captureStandardOutput='true' flowId='19']
##teamcity[testFinished name='"before each" hook' flowId='19']
##teamcity[testFailed name='Test' message='Error' captureStandardOutput='true' flowId='19']
##teamcity[testFinished name='Test' duration='6166' flowId='19']
```

So to fix the issue I added postfix `_hook` to flowId that is logged for hooks only.

